### PR TITLE
Adding instructions for using slurm from within the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,8 @@ FROM python:3.11
 RUN apt-get update && apt-get install -y curl wget git
 
 RUN pip install numpy
+
+# This is required if you want to use slurm inside the container
+# (in addition to the slurm installation on the host machine, and
+# the corresponding libraries mounted into the container)
+RUN adduser --disabled-password --gecos "" slurm

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ when you run the container with singularity.
 
 Example:
 ```shell
-singularity exec -B /home -B /beegfs -B /usr/bin/scancel,/usr/bin/squeue,/usr/bin/sbatch,/usr/bin/sinfo,/usr/lib64/libreadline.so.6,/usr/lib64/libhistory.so.6,/usr/lib64/libtinfo.so.5,/var/run/munge,/usr/lib64/libmunge.so.2,/usr/lib64/libmunge.so.2.0.0,/run/munge,/etc/slurm,/usr/lib64/slurm docker://jobirk/eshell /bin/zsh
+singularity exec -B /home -B /beegfs -B /usr/bin/scancel,/usr/bin/squeue,/usr/bin/sbatch,/usr/bin/sinfo,/usr/lib64/libreadline.so.6,/usr/lib64/libhistory.so.6,/usr/lib64/libtinfo.so.5,/var/run/munge,/usr/lib64/libmunge.so.2,/usr/lib64/libmunge.so.2.0.0,/run/munge,/etc/slurm,/usr/lib64/slurm docker://jobirk/docker-on-maxwell /bin/bash
 ```
 
 This command will run the container `jobirk/eshell` with the specified libraries

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you know already what Docker and Singularity are, you can go straight to the
     - [`Dockerfile`](#dockerfile)
     - [`.ssh/config` file setup](#sshconfig-file-setup)
     - [VSCode settings](#vscode-settings)
+  - [Slurm support](#slurm-support)
 
 <!-- tocstop -->
 
@@ -404,3 +405,19 @@ Also create the directory on the remote machine:
 ```shell
 mkdir -p /beegfs/desy/user/<username>/.vscode-container/<container-name>
 ```
+
+## Slurm support
+
+If you want to be able to submit jobs to the cluster from within the container,
+you need to add the required libraries to the container with the `-B` flag
+when you run the container with singularity.
+
+Example:
+```shell
+singularity exec -B /home -B /beegfs -B /usr/bin/scancel,/usr/bin/squeue,/usr/bin/sbatch,/usr/bin/sinfo,/usr/lib64/libreadline.so.6,/usr/lib64/libhistory.so.6,/usr/lib64/libtinfo.so.5,/var/run/munge,/usr/lib64/libmunge.so.2,/usr/lib64/libmunge.so.2.0.0,/run/munge,/etc/slurm,/usr/lib64/slurm docker://jobirk/eshell /bin/zsh
+```
+
+This command will run the container `jobirk/eshell` with the specified libraries
+mounted into the container, i.e. the part
+`-B /usr/bin/scancel,/usr/bin/squeue,/usr/bin/sbatch,/usr/bin/sinfo,/usr/lib64/libreadline.so.6,/usr/lib64/libhistory.so.6,/usr/lib64/libtinfo.so.5,/var/run/munge,/usr/lib64/libmunge.so.2,/usr/lib64/libmunge.so.2.0.0,/run/munge,/etc/slurm,/usr/lib64/slurm`
+is what we need in order to make the slurm commands available in the container.


### PR DESCRIPTION
@ThorstenBuss I got `slurm` to run with this setup.

The only thing that is not working for me yet, is the correct identification of my jobs if I run `squeue -u birkjosc`, but that I can ignore for now with `squeue | grep birkjosc`.

